### PR TITLE
GHC 7.0.2 / text vs. utf8-light

### DIFF
--- a/memcached.cabal
+++ b/memcached.cabal
@@ -17,7 +17,7 @@ build-depends:
   base >3 && <5,
   network,
   bytestring >=0.9 && <0.10,
-  utf8-light >=0.4 && <1.0
+  text
 
 extra-source-files:
   Setup.hs,


### PR DESCRIPTION
This patch makes memcached build on 7.0.2 by replacing utf8-light with text.
